### PR TITLE
html_entity_decode for strings in Settings

### DIFF
--- a/src/Type/Object/Settings.php
+++ b/src/Type/Object/Settings.php
@@ -88,7 +88,7 @@ class Settings {
 									$option = absint( $option );
 									break;
 								case 'string':
-									$option = ! empty( $option ) ? (string) $option : '';
+									$option = ! empty( $option ) ? html_entity_decode( (string) $option ) : '';
 									break;
 								case 'boolean':
 									$option = (bool) $option;


### PR DESCRIPTION
Just a simple one liner to html_decode_entities in the Settings queries. Useful when companies have & symbols (or others) in their name or bylines.