### PR TITLE
ci: fix codeception run command to accept multiple

### DIFF
--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -65,7 +65,7 @@ jobs:
           USING_XDEBUG: ${{ matrix.coverage }}
           DEBUG: ${{ matrix.debug }}
           SKIP_TESTS_CLEANUP: ${{ matrix.coverage }}
-          SUITES: acceptance, functional, wpunit
+          SUITES: acceptance,functional,wpunit
           PHP_VERSION: ${{ matrix.php }}
           WP_VERSION: ${{ matrix.wordpress }}
         run: composer run-test

--- a/docker/testing.entrypoint.sh
+++ b/docker/testing.entrypoint.sh
@@ -17,10 +17,9 @@ run_tests() {
         exit 1
     fi
 
-    for suite in $suites ; do
-        echo "Running Test Suite $suite"
-        vendor/bin/codecept run -c codeception.dist.yml ${suite} ${coverage:-} ${debug:-} --no-exit
-    done
+    # Suites is the comma separated list of suites/tests to run.
+    echo "Running Test Suite $suites"
+    vendor/bin/codecept run -c codeception.dist.yml ${debug:-} --no-exit -- "${suites}" 
 }
 
 # Exits with a status of 0 (true) if provided version number is higher than proceeding numbers.


### PR DESCRIPTION
I recently learned that the for loop with multiple runs of codecept will overwrite the _output/failed file.  So failures could be ignored at the end of the entrypoint.sh script. A comma separted list with no spaces should execute multiple suites or test files in one run.  Let's see of that resolves the issue.