### PR TITLE
Specify php version for github action composer cache

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -14,6 +14,8 @@ jobs:
   run:
     runs-on: ubuntu-latest
     name: Check code
+    env:
+      PHP_VERSION: 7.4.5
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -21,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4.5
+          php-version: $PHP_VERSION
           extensions: mbstring, intl
           tools: composer
 
@@ -33,8 +35,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer
+          key: php-${{ PHP_VERSION }}-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: php-${{ PHP_VERSION }}-${{ runner.os }}-composer
 
       - name: Install dependencies
         run: composer install --no-progress

--- a/.github/workflows/testing-integration.yml
+++ b/.github/workflows/testing-integration.yml
@@ -47,8 +47,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composercache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: php-${{ matrix.php }}-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: php-${{ matrix.php }}-${{ runner.os }}-composer-
 
       - name: Install dependencies
         run: composer install --no-dev

--- a/.github/workflows/wordpress-coding-standards.yml
+++ b/.github/workflows/wordpress-coding-standards.yml
@@ -13,6 +13,8 @@ jobs:
   run:
     runs-on: ubuntu-latest
     name: Check code
+    env:
+      PHP_VERSION: 7.4
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -20,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: $PHP_VERSION
           extensions: mbstring, intl
           tools: composer
 
@@ -32,8 +34,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer
+          key: php-${{ PHP_VERSION }}-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: php-${{ PHP_VERSION }}-${{ runner.os }}-composer
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Your checklist for this pull request
Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Make sure you are making a pull request against the **develop branch** (left side). Also you should start *your branch* off *our develop*.
- [ ] Make sure you are requesting to pull request from a **topic/feature/bugfix branch** (right side). Don't pull request from your master!

What does this implement/fix? Explain your changes.
---------------------------------------------------
Use specific version of PHP as part of the composer cache in the github actions.


Does this close any currently open issues?
------------------------------------------
…


Any relevant logs, error output, GraphiQL screenshots, etc?
-------------------------------------
(If it’s long, please paste to https://ghostbin.com/ and insert the link here.)


Any other comments?
-------------------
…


Where has this been tested?
---------------------------
**Operating System:** …

**WordPress Version:** …
